### PR TITLE
[DOC] Replace sklearn with scikit-learn in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following Critical Difference Diagram (CDD) shows the comparison following t
 ```
 numpy
 pandas
-sklearn
+scikit-learn
 tensorflow
 matplotlib
 codecarbon


### PR DESCRIPTION
Replace sklearn with scikit-learn in requirements for easier copy/paste pip install.